### PR TITLE
Add simple stock analysis tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,21 @@
 # devnet
+
+This repository contains a simple stock analysis script.
+
+## Setup
+
+Install the required dependencies:
+
+```bash
+pip install yfinance matplotlib
+```
+
+## Usage
+
+Run the script with a ticker symbol and date range:
+
+```bash
+python stock_analysis.py --symbol AAPL --start 2020-01-01 --end 2020-12-31
+```
+
+This will print the first rows of the data with 20-day moving average and show a plot.

--- a/stock_analysis.py
+++ b/stock_analysis.py
@@ -1,0 +1,39 @@
+import argparse
+import sys
+
+try:
+    import yfinance as yf
+    import matplotlib.pyplot as plt
+except ImportError as e:
+    print("Required packages are missing: {}".format(e))
+    sys.exit(1)
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Simple stock analysis tool")
+    parser.add_argument('--symbol', required=True, help='Ticker symbol, e.g., AAPL')
+    parser.add_argument('--start', required=True, help='Start date YYYY-MM-DD')
+    parser.add_argument('--end', required=True, help='End date YYYY-MM-DD')
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+    data = yf.download(args.symbol, start=args.start, end=args.end)
+    if data.empty:
+        print("No data found for symbol {}".format(args.symbol))
+        return
+
+    data['Return'] = data['Adj Close'].pct_change()
+    data['MA20'] = data['Adj Close'].rolling(window=20).mean()
+
+    print(data[['Adj Close', 'Return', 'MA20']].dropna().head())
+
+    data[['Adj Close', 'MA20']].plot(title=f'{args.symbol} Adj Close and 20-day MA')
+    plt.xlabel('Date')
+    plt.ylabel('Price ($)')
+    plt.tight_layout()
+    plt.show()
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- implement `stock_analysis.py` that fetches historical quotes, computes returns, and plots a 20-day moving average
- update README with setup and usage instructions

## Testing
- `python -m py_compile stock_analysis.py`
- `pytest -q`
- `python stock_analysis.py --symbol AAPL --start 2020-01-01 --end 2020-12-31` *(fails: Required packages are missing)*

------
https://chatgpt.com/codex/tasks/task_e_68465a7c2864832886af931497bc9320